### PR TITLE
Pass element to handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@ export default (element, handler) => {
 	let frame = document.createElement('iframe');
 	frame.style.cssText = CSS;
 	element.appendChild(frame);
-	frame.contentWindow.onresize = () => { handler(); };
+	frame.contentWindow.onresize = () => { handler(element); };
 	return frame;
 }


### PR DESCRIPTION
It's useful when the handler is defined elsewhere:

```js
function handler (element) {
    //
}

observeResize(document.querySelector('.on-the-fly'), handler);
```