### PR TITLE
Fix type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const CSS = 'position:absolute;left:0;top:-100%;width:100%;height:100%;margin:1p
 export default (element, handler) => {
 	let frame = document.createElement('iframe');
 	frame.style.cssText = CSS;
+	frame.onload = () => frame.contentWindow.onresize = () => handler(element);
 	element.appendChild(frame);
-	frame.contentWindow.onresize = () => { handler(element); };
 	return frame;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-element-resize-detector",
   "amdName": "simpleElementResizeDetector",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Observes resizing of an element using a hidden iframe.",
   "main": "dist/simple-element-resize-detector.js",
   "jsnext:main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-element-resize-detector",
   "amdName": "simpleElementResizeDetector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Observes resizing of an element using a hidden iframe.",
   "main": "dist/simple-element-resize-detector.js",
   "jsnext:main": "index.js",


### PR DESCRIPTION
This change fixes a type error which would happen on some browsers where `frame.contentWindow` wouldn't be defined immediately. 

Fixes #9 